### PR TITLE
Fix double commit issue with Resolveable puts. Replace resolveMany' with resolveMany.

### DIFF
--- a/src/Network/Riak/Resolvable/Internal.hs
+++ b/src/Network/Riak/Resolvable/Internal.hs
@@ -131,7 +131,7 @@ put doPut conn bucket key mvclock0 val0 w dw = do
         case xs of
           [x] | i > 0 || isJust mvclock -> return (x, vclock)
           (_:_) -> do debugValues "put" "conflict" xs
-                      go (i+1) (resolveMany' val xs) (Just vclock)
+                      go (i+1) (resolveMany xs) (Just vclock)
           []    -> unexError "Network.Riak.Resolvable" "put"
                    "received empty response from server"
   go (0::Int) val0 mvclock0
@@ -189,7 +189,7 @@ putMany doPut conn bucket puts0 w dw = go (0::Int) [] . zip [(0::Int)..] $ puts0
   mush (i,(k,mv,c)) (cs,v) =
       case cs of
         [x] | i > 0 || isJust mv -> Right (i,(x,v))
-        (_:_) -> Left (i,(k,Just v, resolveMany' c cs))
+        (_:_) -> Left (i,(k,Just v, resolveMany cs))
         []    -> unexError "Network.Riak.Resolvable" "put"
                  "received empty response from server"
 {-# INLINE putMany #-}


### PR DESCRIPTION
Values are `resolved` twice for every resolvable `put`.  This means that if you put a value `a` then what ends up in Riak is `resolve a a`.  This is fine for structures like sets but not so much for other structures.

On reading the documentation I thought the following behavior was described:
    put bucket key a
    -- `a` is now stored in Riak under the bucket key pair bucket, key
    put bucket key a1
    -- `resolve a a1` is now stored in Riak under the bucket key pair bucket, key

The committed files give the above behavior for the small number of by hand tests I have preformed. If this is the preferred behavior I will try and come up with some monadic QuickCheck code to test it.

Here is a code snippet that produces this issue with the current version of the riak package.

```
newtype SingularJSON a =   SingularJSON { getSingularJSON :: [a] }          
    deriving (Show, Generic)                                                     

deriving instance (FromJSON a) => FromJSON (SingularJSON a)                      
deriving instance (ToJSON a) => ToJSON (SingularJSON a)                          

instance (Resolvable a) => Resolvable (SingularJSON a) where                     
    resolve (SingularJSON [a]) (SingularJSON [b]) = SingularJSON $ [resolve a b] 

type SingularSum a = SingularJSON (ResolvableMonoid (Sum a))                     


> let a = SingularJSON . (\x -> [x]) . RM . Sum $ (1::Int)                     
> withConnection pool $ \conn -> RJ.put conn "test" "test Nothing (a :: SingularSum Int) Default Default                                                
-- report bacck value of SingularJSON {getSingularJSON = [RM {unRM = Sum {getSum = 2}}]
```
