### PR TITLE
Fix compilation warnings.

### DIFF
--- a/src/Network/Riak/Request.hs
+++ b/src/Network/Riak/Request.hs
@@ -45,7 +45,7 @@ module Network.Riak.Request
     ) where
 
 import Control.Applicative ((<$>))
-import Network.Riak.Protocol.BucketProps
+import Network.Riak.Protocol.BucketProps hiding (r,rw)
 import Network.Riak.Protocol.Content
 import Network.Riak.Protocol.GetClientIDRequest
 import Network.Riak.Protocol.GetServerInfoRequest

--- a/src/Network/Riak/Resolvable/Internal.hs
+++ b/src/Network/Riak/Resolvable/Internal.hs
@@ -186,7 +186,7 @@ putMany doPut conn bucket puts0 w dw = go (0::Int) [] . zip [(0::Int)..] $ puts0
     unless (null conflicts) $
       debugValues "putMany" "conflicts" conflicts
     go (i+1) (ok++acc) conflicts
-  mush (i,(k,mv,c)) (cs,v) =
+  mush (i,(k,mv,_)) (cs,v) =
       case cs of
         [x] | i > 0 || isJust mv -> Right (i,(x,v))
         (_:_) -> Left (i,(k,Just v, resolveMany cs))


### PR DESCRIPTION
First warning was about an un-used variable c, the second warnings were about shadowing variables imported from Network.Riak.Protocol.BucketProps.