### PR TITLE
Use non-forked version of protocol-buffers packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .cabal-sandbox
 cabal.sandbox.config
 TAGS
+.stack-work
+*~

--- a/protobuf/riak-protobuf.cabal
+++ b/protobuf/riak-protobuf.cabal
@@ -78,8 +78,8 @@ library
     array >= 0.4,
     base == 4.*,
     parsec >= 3,
-    protocol-buffers-fork == 2.0.*,
-    protocol-buffers-descriptor-fork == 2.0.*
+    protocol-buffers >= 2.1.0 && < 2.2,
+    protocol-buffers-descriptor >= 2.1.0 && < 2.2
 
   ghc-options: -Wall -fno-warn-orphans
 

--- a/riak.cabal
+++ b/riak.cabal
@@ -93,7 +93,7 @@ library
     monad-control >= 0.2.0.1,
     network >= 2.3,
     resource-pool == 0.2.*,
-    protocol-buffers-fork == 2.0.*,
+    protocol-buffers >= 2.1.0 && < 2.2,
     pureMD5,
     random,
     riak-protobuf == 0.18.*,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+packages:
+- '.'
+- protobuf/
+extra-deps:
+- protocol-buffers-2.1.0
+- protocol-buffers-descriptor-2.1.0
+resolver: lts-2.16


### PR DESCRIPTION
I took maintainership over protocol-buffers repo, released new package versions and propose to use these packages.

I also add stack tool support. You can now build this package easily by running `stack build`, run all tests by `stack test` and upload package by `stack upload` (this one needs separate run for each package). Very nice tool!