### PR TITLE
Bump ranges for protobuf.

### DIFF
--- a/protobuf/riak-protobuf.cabal
+++ b/protobuf/riak-protobuf.cabal
@@ -9,7 +9,7 @@ homepage:            http://github.com/markhibberd/riak-haskell-client
 license:             OtherLicense
 license-file:        LICENSE
 author:              Bryan O'Sullivan <bos@mailrank.com>
-maintainer:          Mark Hibberd <mark@hibberd.id.au>
+maintainer:          Mark Hibberd <mark@hibberd.id.au>, Tim McGilchrist <timmcgil@gmail.com>
 copyright:           Copyright 2011 MailRank, Inc.
                      Portions copyright 2007-2010 Basho Technologies, Inc.
 category:            Network
@@ -110,8 +110,8 @@ library
     array >= 0.4,
     base == 4.*,
     parsec >= 3,
-    protocol-buffers >= 2.1.4 && < 2.2,
-    protocol-buffers-descriptor >= 2.1.4 && < 2.2
+    protocol-buffers >= 2.1.4 && < 2.3,
+    protocol-buffers-descriptor >= 2.1.4 && < 2.3
 
   ghc-options: -Wall -fno-warn-orphans
 

--- a/riak.cabal
+++ b/riak.cabal
@@ -116,7 +116,7 @@ library
                 monad-control                 >= 1.0.0.4 && < 1.1,
                 network                       >= 2.3,
                 resource-pool                 == 0.2.*,
-                protocol-buffers              >= 2.1.4 && < 2.2,
+                protocol-buffers              >= 2.1.4 && < 2.3,
                 pureMD5,
                 random,
                 random-shuffle                >= 0.0.4 && < 0.1,


### PR DESCRIPTION
https://github.com/markhibberd/riak-haskell-client/issues/35

@markhibberd took the liberty of adding myself as a maintainer to the riak-protobuf library.