### PR TITLE
Cluster split fix

### DIFF
--- a/riak.cabal
+++ b/riak.cabal
@@ -120,7 +120,6 @@ library
                 protocol-buffers              >= 2.1.4 && < 2.3,
                 pureMD5,
                 random,
-                random-shuffle                >= 0.0.4 && < 0.1,
                 riak-protobuf                 == 0.21.*,
                 semigroups                    >= 0.16,
                 stm                           == 2.4.*,


### PR DESCRIPTION
It appeared that my previous fix was faulty as `mersenne-random-pure64` doesn't support `split`, this patch simplifies approach a bit (uses rotation instead of shuffle e.g.) and enables correct random node selection