### PR TITLE
Catch connection errors

### DIFF
--- a/src/Network/Riak/Cluster.hs
+++ b/src/Network/Riak/Cluster.hs
@@ -68,10 +68,8 @@ inCluster Cluster{clusterPools=pools, clusterGen=tMT} f = do
     go pools' []
   where
     go [] errors = throwM (InClusterError errors)
-    go (p:ps) es = Riak.withConnectionM p $ \c -> do
-        er <- tryAny (f c)
-        either (\err -> go ps (err:es))
-               return er
+    go (p:ps) es =
+        catchAny (Riak.withConnectionM p f) (\e -> go ps (e:es))
 
 rotateL :: Int -> [a] -> [a]
 rotateL i xs = right ++ left

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ packages:
 - '.'
 - protobuf/
 extra-deps:
-- protocol-buffers-2.1.6
-- protocol-buffers-descriptor-2.1.6
-resolver: lts-2.16
+- protocol-buffers-2.4.0
+- protocol-buffers-descriptor-2.4.0
+resolver: nightly-2016-07-11


### PR DESCRIPTION
So, our two production nodes went ouf of space, thus we've noticed that `inCluster` doesn't catch all the things that it needs to catch.

Checked this code on prod, seems to work fine so far.