### PR TITLE
Bump aeson upper bound to <1.1

### DIFF
--- a/riak.cabal
+++ b/riak.cabal
@@ -99,7 +99,7 @@ library
     Network.Riak.Tag
 
   build-depends:
-                aeson                         >= 0.8      && < 0.12,
+                aeson                         >= 0.8      && < 1.1,
                 attoparsec                    >= 0.12.1.6 && < 0.14,
                 base                          >= 3        && <5,
                 binary,


### PR DESCRIPTION
I tested the build against `aeson-1.0.0.0` by:

- changing the version to `aeson == 1.0.0.0` in the cabal file
- `stack solver --update-config`
- `stack build`