### PR TITLE
Bump stack.yaml to lts-7.2 and clean up old resolvers

### DIFF
--- a/.stack-7.10.3.yaml
+++ b/.stack-7.10.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.2
+resolver: lts-6.19
 packages:
 - '.'
 - protobuf/

--- a/.stack-7.8.4.yaml
+++ b/.stack-7.8.4.yaml
@@ -1,0 +1,7 @@
+resolver: lts-2.22
+packages:
+- '.'
+- protobuf/
+extra-deps:
+- protocol-buffers-2.1.6
+- protocol-buffers-descriptor-2.1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   # stack
   - mkdir -p ~/.local/bin
   - export PATH=~/.local/bin:$PATH
-  - curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-linux-x86_64.tar.gz | tar xz -C /tmp; mv /tmp/stack-0.1.6.0-linux-x86_64/stack ~/.local/bin
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - ulimit -n 4096
   # riak
   - sudo apt-get -y install build-essential libc6-dev-i386 git
@@ -43,23 +43,32 @@ before_install:
 
 matrix:
   include:
-    - env: GHCVER=7.8.4 STACK_YAML=stack.yaml RIAK=2.1.3
+    - env: GHCVER=7.8.4 ARGS="--stack-yaml=.stack-7.8.4.yaml" RIAK=2.1.3
       addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.8.4 STACK_YAML=stack.yaml RIAK=2.0.6
+    - env: GHCVER=7.8.4 ARGS="--stack-yaml=.stack-7.8.4.yaml" RIAK=2.0.6
       addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml RIAK=2.1.3
+
+    - env: GHCVER=7.10.3 ARGS="--stack-yaml=.stack-7.10.3.yaml" RIAK=2.1.3
       addons: {apt: {packages: [ghc-7.10.3],sources: [hvr-ghc]}}
-    - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml RIAK=2.0.6
+    - env: GHCVER=7.10.3 ARGS="--stack-yaml=.stack-7.10.3.yaml" RIAK=2.0.6
       addons: {apt: {packages: [ghc-7.10.3],sources: [hvr-ghc]}}
-    - env: GHCVER=head STACK_YAML=stack-head.yaml RIAK=2.1.3
-      addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
+
+    - env: GHCVER=8.0.1 ARGS="" RIAK=2.1.3
+      addons: {apt: {packages: [ghc-8.0.1],sources: [hvr-ghc]}}
+    - env: GHCVER=8.0.1 ARGS="" RIAK=2.0.6
+      addons: {apt: {packages: [ghc-8.0.1],sources: [hvr-ghc]}}
+
+    - env: GHCVER=head ARGS="--resolver=nightly" RIAK=2.1.3
+      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+    - env: GHCVER=head ARGS="--resolver=nightly" RIAK=2.0.6
+      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
 
   allow_failures:
-   - env: GHCVER=head STACK_YAML=stack-head
+    - env: GHCVER=head ARGS="--resolver=nightly" RIAK=2.1.3
+    - env: GHCVER=head ARGS="--resolver=nightly" RIAK=2.0.6
 
 install:
-  - stack --no-terminal --skip-ghc-check setup
-  - stack --no-terminal --skip-ghc-check test --only-snapshot
+  - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:
-  - stack --no-terminal --skip-ghc-check test
+  - stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,6 +1,0 @@
-flags: {}
-packages:
-- '.'
-- protobuf/
-extra-deps: []
-resolver: lts-3.1

--- a/stack-head.yaml
+++ b/stack-head.yaml
@@ -1,6 +1,0 @@
-flags: {}
-packages:
-- '.'
-- protobuf/
-extra-deps: []
-resolver: nightly-2015-12-20


### PR DESCRIPTION
I updated the default resolver to 7.2 from 2.16, and I also cleaned up the other stack.yamls lying around.

Now, we build on riak-2.1.3 and riak-2.0.6 on each of ghc-7.8.4, ghc-7.10.3, ghc-8.0.1, and with the nightly resolver

Still TODO: Pass travis