### PR TITLE
Move setup from .travis.yml into test main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - ./rel/riak/bin/riak start
   - ./rel/riak/bin/riak ping
   - cd -
+  - export PATH=$PWD/riak-$RIAK/rel/riak/bin:$PATH
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,23 +22,6 @@ before_install:
   - sed -r --in-place -e 's/^(search) = .*/\1 = on/' rel/riak/etc/riak.conf
   - ./rel/riak/bin/riak start
   - ./rel/riak/bin/riak ping
-  - ./rel/riak/bin/riak-admin wait-for-service riak_kv
-  - ./rel/riak/bin/riak-admin wait-for-service yokozuna
-  # CRDTs
-  - ./rel/riak/bin/riak-admin bucket-type create maps '{"props":{"datatype":"map"}}'
-  - ./rel/riak/bin/riak-admin bucket-type create sets '{"props":{"datatype":"set"}}'
-  - ./rel/riak/bin/riak-admin bucket-type create counters '{"props":{"datatype":"counter"}}'
-  - ./rel/riak/bin/riak-admin bucket-type activate maps
-  - ./rel/riak/bin/riak-admin bucket-type activate sets
-  - ./rel/riak/bin/riak-admin bucket-type activate counters
-  # plain bucket-types
-  - ./rel/riak/bin/riak-admin bucket-type create untyped-1 '{"props":{}}'
-  - ./rel/riak/bin/riak-admin bucket-type create untyped-2 '{"props":{}}'
-  - ./rel/riak/bin/riak-admin bucket-type activate untyped-1
-  - ./rel/riak/bin/riak-admin bucket-type activate untyped-2
-  # +search
-  - curl -XPUT 127.0.0.1:8098/search/index/set-ix -H 'Content-Type:application/json' -d '{"schema":"_yz_default"}'
-  - ./rel/riak/bin/riak-admin bucket-type update sets '{"props":{"search_index":"set-ix"}}'
   - cd -
 
 matrix:

--- a/riak.cabal
+++ b/riak.cabal
@@ -142,8 +142,8 @@ library
 test-suite test
   type: exitcode-stdio-1.0
   main-is: Test.hs
-  hs-source-dirs: tests
-  ghc-options: -Wall
+  hs-source-dirs: tests, tests/dsl
+  ghc-options: -Wall -threaded
 
   if flag(test2i)
     cpp-options: -DTEST2I
@@ -152,6 +152,8 @@ test-suite test
     Properties
     CRDTProperties
     Common
+    Utils
+    Network.Riak.Admin.DSL
 
   build-depends:
     base,
@@ -160,6 +162,7 @@ test-suite test
     bytestring,
     containers,
     HUnit,
+    process,
     QuickCheck,
     tasty,
     tasty-hunit,

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE LambdaCase         #-}
+
+module Utils where
+
+import Control.Applicative
+import Control.Exception
+import Control.Monad
+import Data.Typeable
+import System.Exit
+import System.Timeout
+
+import qualified System.Process as Process
+
+
+data ShellFailure
+  = ShellFailure Int String
+  | ShellTimeout String
+  deriving (Show, Typeable)
+
+instance Exception ShellFailure
+
+-- | Run a shell command (inheriting stdin, stdout, and stderr), and throw an
+-- exception if it fails. Time out after 10 seconds.
+shell :: String -> IO ()
+shell s =
+  timeout (10*1000*1000) act >>= \case
+    Nothing -> throw (ShellTimeout s)
+    _       -> pure ()
+  where
+    act :: IO ()
+    act =
+      bracketOnError
+        (do
+          (_, _, _, h) <- Process.createProcess (Process.shell s)
+          pure h)
+        Process.terminateProcess
+        (Process.waitForProcess >=> \case
+          ExitSuccess -> pure ()
+          ExitFailure n -> throw (ShellFailure n s))

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -21,10 +21,10 @@ data ShellFailure
 instance Exception ShellFailure
 
 -- | Run a shell command (inheriting stdin, stdout, and stderr), and throw an
--- exception if it fails. Time out after 10 seconds.
+-- exception if it fails. Time out after 30 seconds.
 shell :: String -> IO ()
 shell s =
-  timeout (10*1000*1000) act >>= \case
+  timeout (30*1000*1000) act >>= \case
     Nothing -> throw (ShellTimeout s)
     _       -> pure ()
   where

--- a/tests/dsl/Network/Riak/Admin/DSL.hs
+++ b/tests/dsl/Network/Riak/Admin/DSL.hs
@@ -1,0 +1,58 @@
+-- | A simple "riak-admin DSL", which is nothing more than strings of stitched
+-- together riak-admin shell commands.
+
+module Network.Riak.Admin.DSL
+  ( -- * Riak admin commands
+    waitForService
+  , bucketTypeCreate
+  , bucketTypeActivate
+    -- * Riak admin runners
+  , riakAdmin
+  , riakAdminDocker
+  ) where
+
+import Utils
+
+
+-- | Bucket props string, e.g. "{\"props\":{\"n_val\":\"1\"}}"
+type BucketProps = String
+
+type BucketTypeName = String
+
+-- | Docker container id or name
+type ContainerId = String
+
+-- | Erlang node name, e.g. "riak@172.17.0.2"
+type NodeName = String
+
+-- | riak-admin shell command
+type RiakAdmin = String
+
+-- | Riak service name, e.g. "yokozuna"
+type ServiceName = String
+
+
+-- | riak-admin wait-for-service
+waitForService :: ServiceName -> Maybe NodeName -> RiakAdmin
+waitForService name node =
+  "riak-admin wait-for-service " ++ name ++ maybe "" (" " ++) node
+
+-- | riak-admin bucket-type create
+bucketTypeCreate :: BucketTypeName -> Maybe BucketProps -> RiakAdmin
+bucketTypeCreate name props =
+  "riak-admin bucket-type create " ++ name ++ maybe "" (" " ++) props
+
+-- | riak-admin bucket-type activate
+bucketTypeActivate :: BucketTypeName -> RiakAdmin
+bucketTypeActivate name = "riak-admin bucket-type activate " ++ name
+
+
+-- | Run a list of riak-admin commands locally, and throw an exception if any of
+-- them fail.
+riakAdmin :: [RiakAdmin] -> IO ()
+riakAdmin = mapM_ shell
+
+-- | Run a list of riak-admin commands inside a Docker container, and throw an
+-- exception if any of them fail.
+riakAdminDocker :: ContainerId -> [RiakAdmin] -> IO ()
+riakAdminDocker name = riakAdmin . map (\c -> "docker exec " ++ name ++ " " ++ c)


### PR DESCRIPTION
This patch moves the shell code in `.travis.yml` to a little preamble in `tests/Test.hs`, as part of my effort to make this test suite runnable locally.

Still lots TODO (for later patches), for example, the current test suite will fail when run a second time locally, because creating a bucket type that already exists is an error (or something along those lines).