### PR TITLE
Modify SearchResult to include all returned fields

### DIFF
--- a/src/Network/Riak/Response.hs
+++ b/src/Network/Riak/Response.hs
@@ -39,8 +39,8 @@ import Network.Riak.Protocol.GetClientIDResponse
 import Network.Riak.Protocol.GetResponse
 import Network.Riak.Protocol.ListBucketsResponse
 import Network.Riak.Protocol.PutResponse
-import Network.Riak.Protocol.SearchQueryResponse
-import Network.Riak.Protocol.SearchDoc
+import qualified Network.Riak.Protocol.SearchQueryResponse as Q
+import qualified Network.Riak.Protocol.SearchDoc as Q
 import qualified Network.Riak.Protocol.YzIndexGetResponse as Yz
 import Network.Riak.Types.Internal hiding (MessageTag(..))
 import qualified Network.Riak.Protocol.Link as Link
@@ -53,7 +53,9 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import Data.Semigroup
 import Control.Arrow ((&&&))
-import Data.Foldable (toList)
+import Control.Monad (join)
+import Data.Foldable (foldMap, toList)
+import Text.Read (readMaybe)
 
 getClientID :: GetClientIDResponse -> ClientID
 getClientID = client_id
@@ -90,28 +92,38 @@ unescapeLinks c = c { links = go <$> links c }
   where go l = l { Link.bucket = unescape <$> Link.bucket l
                  , Link.key = unescape <$> Link.key l }
 
-search :: SearchQueryResponse -> [SearchResult]
-search = map toSearchResult . toList . docs
+search :: Q.SearchQueryResponse -> SearchResult
+search resp =
+  SearchResult
+    { docs = map (toSearchDoc . foldMap kv . Q.fields) (toList (Q.docs resp))
+    , maxScore = Q.max_score resp
+    , numFound = Q.num_found resp
+    }
+  where
+    kv :: Pair.Pair -> M.Map L.ByteString (Maybe L.ByteString)
+    kv pair = M.singleton (Pair.key pair) (Pair.value pair)
 
-toSearchResult :: SearchDoc -> SearchResult
-toSearchResult r = SearchResult {
-                     bucketType = field "_yz_rt",
-                     bucket     = field "_yz_rb",
-                     key        = field "_yz_rk",
-                     score      = fmap (read . LC.unpack) =<< M.lookup "score" info
-                   }
-    where
-      info :: M.Map L.ByteString (Maybe L.ByteString)
-      info = M.fromList . map (Pair.key &&& Pair.value) . toList . fields $ r
+    toSearchDoc :: M.Map L.ByteString (Maybe L.ByteString) -> SearchDoc
+    toSearchDoc m0 =
+      SearchDoc
+        { id         = fromMaybe (unexpected "missing \"_yz_id\"") (join i)
+        , bucketType = fromMaybe (unexpected "missing \"_yz_rt\"") (join bt)
+        , bucket     = fromMaybe (unexpected "missing \"_yz_rb\"") (join b)
+        , key        = fromMaybe (unexpected "missing \"_yz_rk\"") (join k)
+        , score      = join s >>= readMaybe . LC.unpack
+        , fields     = m5
+        }
+      where
+        (i,  m1) = deleteLookup "_yz_id" m0
+        (bt, m2) = deleteLookup "_yz_rt" m1
+        (b,  m3) = deleteLookup "_yz_rb" m2
+        (k,  m4) = deleteLookup "_yz_rk" m3
+        (s,  m5) = deleteLookup "score"  m4
 
-      field :: L.ByteString -> L.ByteString
-      field name
-          = maybe (unexpected $ "field " <> show name <> " has empty value") id
-            . maybe (unexpected $ "no " <> show name <> " field") id
-            . M.lookup name $ info
+    deleteLookup :: Ord k => k -> M.Map k v -> (Maybe v, M.Map k v)
+    deleteLookup k m = (M.lookup k m, M.delete k m)
 
-      unexpected = unexError "Network.Riak.Response" "search"
-
+    unexpected = unexError "Network.Riak.Response" "search"
 
 getIndex :: Yz.YzIndexGetResponse -> [IndexInfo]
 getIndex = toList . Yz.index

--- a/src/Network/Riak/Search.hs
+++ b/src/Network/Riak/Search.hs
@@ -42,6 +42,7 @@ getIndex conn ix = Resp.getIndex <$> exchange conn (Req.getIndex ix)
 putIndex :: Connection -> IndexInfo -> Maybe Timeout -> IO (Seq Content, VClock)
 putIndex conn info timeout = Resp.put <$> exchange conn (Req.putIndex info timeout)
 
--- | Search by raw 'SearchQuery' request (a bytestring) using an index.
-searchRaw :: Connection -> SearchQuery -> Index -> IO [SearchResult]
+-- | Search by raw 'SearchQuery' request (a 'Data.ByteString.Lazy.Bytestring')
+-- using an 'Index'.
+searchRaw :: Connection -> SearchQuery -> Index -> IO SearchResult
 searchRaw conn q ix = Resp.search <$> exchange conn (Req.search q ix)

--- a/src/Network/Riak/Search.hs
+++ b/src/Network/Riak/Search.hs
@@ -7,7 +7,16 @@
 --
 -- http://docs.basho.com/riak/2.1.3/dev/using/search/
 {-# LANGUAGE CPP #-}
-module Network.Riak.Search where
+module Network.Riak.Search
+  ( IndexInfo
+  , SearchResult(..)
+  , SearchDoc(..)
+  , Score
+  , indexInfo
+  , getIndex
+  , putIndex
+  , searchRaw
+  ) where
 
 #if __GLASGOW_HASKELL__ <= 708
 import           Control.Applicative

--- a/src/Network/Riak/Types/Internal.hs
+++ b/src/Network/Riak/Types/Internal.hs
@@ -202,7 +202,7 @@ data SearchResult = SearchResult
   { docs     :: ![SearchDoc]
   , maxScore :: !(Maybe Float)
   , numFound :: !(Maybe Word32)
-  }
+  } deriving (Eq, Ord, Show)
 
 data SearchDoc = SearchDoc
   { id         :: !ByteString    -- ^ id
@@ -212,7 +212,7 @@ data SearchDoc = SearchDoc
   , score      :: !(Maybe Score) -- ^ score, if requested
   , fields     :: !(Map ByteString (Maybe ByteString))
     -- ^ additional fields requested by the @fl@ query parameter
-  } deriving (Eq,Show)
+  } deriving (Eq, Ord, Show)
 
 -- | List of (known to us) inbound or outbound message identifiers.
 data MessageTag = ErrorResponse

--- a/src/Network/Riak/Types/Internal.hs
+++ b/src/Network/Riak/Types/Internal.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable, FunctionalDependencies, MultiParamTypeClasses,
-    RecordWildCards, DeriveGeneric #-}
+{-# LANGUAGE BangPatterns, DeriveDataTypeable, FunctionalDependencies,
+    MultiParamTypeClasses, RecordWildCards, DeriveGeneric #-}
 
 -- |
 -- Module:      Network.Riak.Types.Internal
@@ -34,6 +34,8 @@ module Network.Riak.Types.Internal
     , Tag
     , SearchQuery
     , SearchResult(..)
+    , SearchDoc(..)
+    , Score
     , IndexInfo
     , VClock(..)
     , Job(..)
@@ -60,6 +62,7 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Digest.Pure.MD5 (md5)
 import           Data.Hashable (Hashable)
 import           Data.IORef (IORef)
+import           Data.Map (Map)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
@@ -195,12 +198,21 @@ type N = Word32
 type Timeout = Word32
 
 -- | Solr search result
-data SearchResult = SearchResult {
-      bucketType :: BucketType, -- ^ bucket type
-      bucket :: Bucket,         -- ^ bucket
-      key :: Key,               -- ^ key
-      score :: Maybe Score      -- ^ score, if provided
-    } deriving (Eq,Show)
+data SearchResult = SearchResult
+  { docs :: [SearchDoc]
+  , maxScore :: Maybe Float
+  , numFound :: Maybe Word32
+  }
+
+data SearchDoc = SearchDoc
+  { id         :: !ByteString    -- ^ id
+  , bucketType :: !BucketType    -- ^ bucket type
+  , bucket     :: !Bucket        -- ^ bucket
+  , key        :: !Key           -- ^ key
+  , score      :: !(Maybe Score) -- ^ score, if requested
+  , fields     :: !(Map ByteString (Maybe ByteString))
+    -- ^ additional fields requested by the @fl@ query parameter
+  } deriving (Eq,Show)
 
 -- | List of (known to us) inbound or outbound message identifiers.
 data MessageTag = ErrorResponse

--- a/src/Network/Riak/Types/Internal.hs
+++ b/src/Network/Riak/Types/Internal.hs
@@ -199,9 +199,9 @@ type Timeout = Word32
 
 -- | Solr search result
 data SearchResult = SearchResult
-  { docs :: [SearchDoc]
-  , maxScore :: Maybe Float
-  , numFound :: Maybe Word32
+  { docs     :: ![SearchDoc]
+  , maxScore :: !(Maybe Float)
+  , numFound :: !(Maybe Word32)
   }
 
 data SearchDoc = SearchDoc

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -203,13 +203,13 @@ search = testCase "basic searchRaw" $ do
            C.sendModify conn btype buck key [C.SetRemove kw]
            delay
            a <- query conn ("set:" <> kw)
-           assertEqual "should not found non-existing" [] a
+           assertEqual "should not found non-existing" (S.SearchResult [] (Just 0.0) (Just 0)) a
            C.sendModify conn btype buck key [C.SetAdd kw]
            delay
            b <- query conn ("set:" <> kw)
-           assertBool "searches specific" $ not (null b)
+           assertBool "searches specific" $ not (null (S.docs b))
            c <- query conn ("set:*")
-           assertBool "searches *" $ not (null c)
+           assertBool "searches *" $ not (null (S.docs c))
     where
       query conn q = S.searchRaw conn q "set-ix"
       (btype,buck,key) = ("sets","xxx","yyy")


### PR DESCRIPTION
Prior to this patch, the fields besides `score` were being thrown away, as well as the `num_found` and `max_score` fields. I modified the `SearchResult` type (really just a better interface to `Protocol.SearchQueryResponse`) to include them.