### PR TITLE
Remove 'toSearchDoc' (it makes wrong assumptions)

### DIFF
--- a/src/Network/Riak/Response.hs
+++ b/src/Network/Riak/Response.hs
@@ -95,7 +95,7 @@ unescapeLinks c = c { links = go <$> links c }
 search :: Q.SearchQueryResponse -> SearchResult
 search resp =
   SearchResult
-    { docs     = map (foldMap kv . Q.fields) (toList (Q.docs resp))
+    { docs     = fmap (foldMap kv . Q.fields) (Q.docs resp)
     , maxScore = Q.max_score resp
     , numFound = Q.num_found resp
     }

--- a/src/Network/Riak/Response.hs
+++ b/src/Network/Riak/Response.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, CPP, OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns, RecordWildCards, CPP, OverloadedStrings #-}
 
 -- |
 -- Module:      Network.Riak.Request
@@ -95,13 +95,13 @@ unescapeLinks c = c { links = go <$> links c }
 search :: Q.SearchQueryResponse -> SearchResult
 search resp =
   SearchResult
-    { docs     = fmap (foldMap kv . Q.fields) (Q.docs resp)
+    { docs     = fmap (fmap unpair . Q.fields) (Q.docs resp)
     , maxScore = Q.max_score resp
     , numFound = Q.num_found resp
     }
   where
-    kv :: Pair.Pair -> M.Map L.ByteString (Maybe L.ByteString)
-    kv pair = M.singleton (Pair.key pair) (Pair.value pair)
+    unpair :: Pair.Pair -> (L.ByteString, Maybe L.ByteString)
+    unpair Pair.Pair{Pair.key, Pair.value} = (key, value)
 
 getIndex :: Yz.YzIndexGetResponse -> [IndexInfo]
 getIndex = toList . Yz.index

--- a/src/Network/Riak/Search.hs
+++ b/src/Network/Riak/Search.hs
@@ -10,7 +10,6 @@
 module Network.Riak.Search
   ( IndexInfo
   , SearchResult(..)
-  , SearchDoc(..)
   , Score
   , indexInfo
   , getIndex

--- a/src/Network/Riak/Types/Internal.hs
+++ b/src/Network/Riak/Types/Internal.hs
@@ -34,7 +34,6 @@ module Network.Riak.Types.Internal
     , Tag
     , SearchQuery
     , SearchResult(..)
-    , SearchDoc(..)
     , Score
     , IndexInfo
     , VClock(..)
@@ -199,19 +198,9 @@ type Timeout = Word32
 
 -- | Solr search result
 data SearchResult = SearchResult
-  { docs     :: ![SearchDoc]
+  { docs     :: ![Map ByteString (Maybe ByteString)]
   , maxScore :: !(Maybe Float)
   , numFound :: !(Maybe Word32)
-  } deriving (Eq, Ord, Show)
-
-data SearchDoc = SearchDoc
-  { id         :: !ByteString    -- ^ id
-  , bucketType :: !BucketType    -- ^ bucket type
-  , bucket     :: !Bucket        -- ^ bucket
-  , key        :: !Key           -- ^ key
-  , score      :: !(Maybe Score) -- ^ score, if requested
-  , fields     :: !(Map ByteString (Maybe ByteString))
-    -- ^ additional fields requested by the @fl@ query parameter
   } deriving (Eq, Ord, Show)
 
 -- | List of (known to us) inbound or outbound message identifiers.

--- a/src/Network/Riak/Types/Internal.hs
+++ b/src/Network/Riak/Types/Internal.hs
@@ -62,6 +62,7 @@ import           Data.Digest.Pure.MD5 (md5)
 import           Data.Hashable (Hashable)
 import           Data.IORef (IORef)
 import           Data.Map (Map)
+import           Data.Sequence (Seq)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
@@ -198,7 +199,7 @@ type Timeout = Word32
 
 -- | Solr search result
 data SearchResult = SearchResult
-  { docs     :: ![Map ByteString (Maybe ByteString)]
+  { docs     :: !(Seq (Map ByteString (Maybe ByteString)))
   , maxScore :: !(Maybe Float)
   , numFound :: !(Maybe Word32)
   } deriving (Eq, Ord, Show)

--- a/src/Network/Riak/Types/Internal.hs
+++ b/src/Network/Riak/Types/Internal.hs
@@ -199,7 +199,7 @@ type Timeout = Word32
 
 -- | Solr search result
 data SearchResult = SearchResult
-  { docs     :: !(Seq (Map ByteString (Maybe ByteString)))
+  { docs     :: !(Seq (Seq (ByteString, Maybe ByteString)))
   , maxScore :: !(Maybe Float)
   , numFound :: !(Maybe Word32)
   } deriving (Eq, Ord, Show)

--- a/tests/dsl/Network/Riak/Admin/DSL.hs
+++ b/tests/dsl/Network/Riak/Admin/DSL.hs
@@ -19,9 +19,6 @@ type BucketProps = String
 
 type BucketTypeName = String
 
--- | Docker container id or name
-type ContainerId = String
-
 -- | Erlang node name, e.g. "riak@172.17.0.2"
 type NodeName = String
 


### PR DESCRIPTION
The original code (which I recently modified) is actually incorrect. There's no guarantee that the `_yz_*` fields are returned - it depends on if `fl` is set.

See https://github.com/basho/yokozuna/blob/24dc4ee01bec7576ae7c4ef8f25e814fb0b29bb8/src/yz_pb_search.erl#L147 - `fl` is used as-is, or else defaults to `*,score`.

So, all we really can do to the returned docs is massage them from:

```haskell
-- protobuf definition, basically
docs :: Seq (ByteString, Maybe ByteString)
```

into a more convenient:

```haskell
Map ByteString (Maybe ByteString)
```

