### PR TITLE
Bump aeson upper bound to include 1.1.*

### DIFF
--- a/riak.cabal
+++ b/riak.cabal
@@ -99,7 +99,7 @@ library
     Network.Riak.Tag
 
   build-depends:
-                aeson                         >= 0.8      && < 1.1,
+                aeson                         >= 0.8      && < 1.2,
                 attoparsec                    >= 0.12.1.6 && < 0.14,
                 base                          >= 3        && <5,
                 binary,
@@ -183,6 +183,3 @@ benchmark bench
     criterion   >= 1.1,
     bytestring  >= 0.10,
     semigroups  >= 0.16
-
-
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,7 @@
-resolver: lts-7.2
+resolver: lts-7.19
 packages:
 - '.'
 - protobuf/
 - protobuf-lens/
+extra-deps:
+- aeson-1.1.0.0


### PR DESCRIPTION
I can remove the `extra-deps` section if you like. I'm just checking the CI passes.